### PR TITLE
Migrate activities API to SQLite persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # Logs and databases #
 ######################
 *.log
+*.db
 *.sql
 *.sqlite
 

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister from activities
+- Persist activity and participant data using SQLite
 
 ## Getting Started
 
@@ -34,17 +36,25 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 ## Data Model
 
-The application uses a simple data model with meaningful identifiers:
+The application uses a SQLite database (`src/data/activities.db`) with a simple schema:
 
-1. **Activities** - Uses activity name as identifier:
+1. **activities**
 
+   - `id` (primary key)
+   - `name` (unique)
    - Description
    - Schedule
    - Maximum number of participants allowed
-   - List of student emails who are signed up
 
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
+2. **activity_participants**
 
-All data is stored in memory, which means data will be reset when the server restarts.
+   - `(activity_id, email)` composite primary key
+   - Stores which students are signed up for each activity
+
+On first run, the database is initialized and seeded with default activities.
+
+## Persistence Notes
+
+- Data now survives server restarts.
+- To reset to a fresh seeded dataset, delete `src/data/activities.db` and restart the app.
+

--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,13 @@ from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
 
+from database import (
+    initialize_database,
+    list_activities,
+    signup_for_activity as db_signup_for_activity,
+    unregister_from_activity as db_unregister_from_activity,
+)
+
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
@@ -19,63 +26,7 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+initialize_database()
 
 
 @app.get("/")
@@ -85,48 +36,28 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return list_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    try:
+        message = db_signup_for_activity(activity_name, email)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"message": message}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    try:
+        message = db_unregister_from_activity(activity_name, email)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"message": message}

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,266 @@
+"""Database access helpers for the activities API.
+
+This module provides a tiny SQLite-backed persistence layer so activity and
+participant data survives process restarts.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, Any
+
+
+BASE_DIR = Path(__file__).parent
+DATA_DIR = BASE_DIR / "data"
+DB_PATH = DATA_DIR / "activities.db"
+
+
+INITIAL_ACTIVITIES = {
+    "Chess Club": {
+        "description": "Learn strategies and compete in chess tournaments",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+    },
+    "Programming Class": {
+        "description": "Learn programming fundamentals and build software projects",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+    },
+    "Gym Class": {
+        "description": "Physical education and sports activities",
+        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+        "max_participants": 30,
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+    },
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+    },
+    "Basketball Team": {
+        "description": "Practice and play basketball with the school team",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+    },
+    "Art Club": {
+        "description": "Explore your creativity through painting and drawing",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+    },
+    "Drama Club": {
+        "description": "Act, direct, and produce plays and performances",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+    },
+    "Math Club": {
+        "description": "Solve challenging problems and participate in math competitions",
+        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
+}
+
+
+def _connect() -> sqlite3.Connection:
+    connection = sqlite3.connect(DB_PATH)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def initialize_database() -> None:
+    """Create schema and seed initial data if this is a fresh database."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    with _connect() as connection:
+        cursor = connection.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL CHECK(max_participants > 0)
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activity_participants (
+                activity_id INTEGER NOT NULL,
+                email TEXT NOT NULL,
+                PRIMARY KEY (activity_id, email),
+                FOREIGN KEY (activity_id) REFERENCES activities(id) ON DELETE CASCADE
+            )
+            """
+        )
+
+        existing_activity_count = cursor.execute(
+            "SELECT COUNT(*) FROM activities"
+        ).fetchone()[0]
+        if existing_activity_count == 0:
+            _seed_initial_data(cursor)
+
+        connection.commit()
+
+
+def _seed_initial_data(cursor: sqlite3.Cursor) -> None:
+    for activity_name, details in INITIAL_ACTIVITIES.items():
+        cursor.execute(
+            """
+            INSERT INTO activities (name, description, schedule, max_participants)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                activity_name,
+                details["description"],
+                details["schedule"],
+                details["max_participants"],
+            ),
+        )
+        activity_id = cursor.lastrowid
+        for email in details["participants"]:
+            cursor.execute(
+                """
+                INSERT INTO activity_participants (activity_id, email)
+                VALUES (?, ?)
+                """,
+                (activity_id, email),
+            )
+
+
+def list_activities() -> Dict[str, Dict[str, Any]]:
+    """Return activities in the same shape as the original in-memory API."""
+    with _connect() as connection:
+        cursor = connection.cursor()
+        rows = cursor.execute(
+            """
+            SELECT
+                a.id,
+                a.name,
+                a.description,
+                a.schedule,
+                a.max_participants,
+                ap.email
+            FROM activities a
+            LEFT JOIN activity_participants ap ON ap.activity_id = a.id
+            ORDER BY a.name, ap.email
+            """
+        ).fetchall()
+
+    activities: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        name = row["name"]
+        if name not in activities:
+            activities[name] = {
+                "description": row["description"],
+                "schedule": row["schedule"],
+                "max_participants": row["max_participants"],
+                "participants": [],
+            }
+        if row["email"] is not None:
+            activities[name]["participants"].append(row["email"])
+
+    return activities
+
+
+def signup_for_activity(activity_name: str, email: str) -> str:
+    """Add an email participant to an activity.
+
+    Raises:
+        KeyError: Activity does not exist.
+        ValueError: Participant already registered or activity is full.
+    """
+    with _connect() as connection:
+        cursor = connection.cursor()
+        activity = cursor.execute(
+            """
+            SELECT id, max_participants
+            FROM activities
+            WHERE name = ?
+            """,
+            (activity_name,),
+        ).fetchone()
+        if activity is None:
+            raise KeyError("Activity not found")
+
+        existing_registration = cursor.execute(
+            """
+            SELECT 1
+            FROM activity_participants
+            WHERE activity_id = ? AND email = ?
+            """,
+            (activity["id"], email),
+        ).fetchone()
+        if existing_registration is not None:
+            raise ValueError("Student is already signed up")
+
+        current_count = cursor.execute(
+            """
+            SELECT COUNT(*)
+            FROM activity_participants
+            WHERE activity_id = ?
+            """,
+            (activity["id"],),
+        ).fetchone()[0]
+        if current_count >= activity["max_participants"]:
+            raise ValueError("Activity is already full")
+
+        cursor.execute(
+            """
+            INSERT INTO activity_participants (activity_id, email)
+            VALUES (?, ?)
+            """,
+            (activity["id"], email),
+        )
+        connection.commit()
+
+    return f"Signed up {email} for {activity_name}"
+
+
+def unregister_from_activity(activity_name: str, email: str) -> str:
+    """Remove an email participant from an activity.
+
+    Raises:
+        KeyError: Activity does not exist.
+        ValueError: Participant is not registered.
+    """
+    with _connect() as connection:
+        cursor = connection.cursor()
+        activity = cursor.execute(
+            """
+            SELECT id
+            FROM activities
+            WHERE name = ?
+            """,
+            (activity_name,),
+        ).fetchone()
+        if activity is None:
+            raise KeyError("Activity not found")
+
+        deleted_rows = cursor.execute(
+            """
+            DELETE FROM activity_participants
+            WHERE activity_id = ? AND email = ?
+            """,
+            (activity["id"], email),
+        ).rowcount
+        if deleted_rows == 0:
+            raise ValueError("Student is not signed up for this activity")
+
+        connection.commit()
+
+    return f"Unregistered {email} from {activity_name}"


### PR DESCRIPTION
## Summary
Migrates the activities API from in-memory dictionaries to a SQLite-backed persistence layer.

## What Changed
- Added a new persistence module in `src/database.py`
- Initialized SQLite schema + seed data on startup
- Refactored existing endpoints in `src/app.py` to read/write through the database layer
- Updated `src/README.md` with persistence behavior and reset instructions
- Added `*.db` to `.gitignore`

## Why
This addresses durability issues where activity and participant data was lost whenever the server restarted.

## Notes
- Endpoint shapes and routes were kept compatible with the current frontend.
- New validation now returns a clear error if an activity is full.

Closes #11